### PR TITLE
Fixed version

### DIFF
--- a/src/pal/__init__.py
+++ b/src/pal/__init__.py
@@ -2,4 +2,4 @@
 
 from .secular import *
 
-__version__ = "1.0."
+__version__ = "1.0.0"


### PR DESCRIPTION
The invalid version string prevents pip from installing pal, see https://peps.python.org/pep-0440/